### PR TITLE
Fixed bearer token usage

### DIFF
--- a/includes/class-cf7-api-admin.php
+++ b/includes/class-cf7-api-admin.php
@@ -592,7 +592,7 @@ endif;
       }
       
       if ( isset($bearer_auth) && $bearer_auth !== '' ) {
-        $args['headers']['Authorization'] = 'Basic ' . base64_encode( $bearer_auth );
+        $args['headers']['Authorization'] = 'Bearer ' . $bearer_auth;
       }
 
       if( $record_type == "xml" ){


### PR DESCRIPTION
I've been having issues using a bearer token to authenticate against an API. While digging through the code I've stumbled upon the implementation of the bearer authentication header which seemed odd, so I fixed it. This has worked for me. 