### PR TITLE
Fix boolean fields in json for acceptance fields

### DIFF
--- a/includes/class-cf7-api-admin.php
+++ b/includes/class-cf7-api-admin.php
@@ -502,6 +502,11 @@ endif;
             $value = reset( $value );
           }
 
+          // handle boolean acceptance fields
+          if( $this->isAcceptanceField($form_key) ) {
+            $value = $value == "" ? "false" : "true";
+          }
+
           $template = str_replace( "[{$form_key}]", $value, $template );
         }
       }

--- a/includes/class-cf7-api-admin.php
+++ b/includes/class-cf7-api-admin.php
@@ -686,4 +686,19 @@ endif;
 
     return $xml;
   }
+
+  /**
+   * @param string $field_name
+   * @return bool
+   */
+  private function isAcceptanceField($field_name) {
+    $field = $this->post->scan_form_tags(
+      array(
+        'type' => 'acceptance',
+        'name' => $field_name
+      )
+    );
+
+    return count($field) == 1;
+  }
 }


### PR DESCRIPTION
Acceptance fields are parsed to invalid json.
The fields were represented: string 1 for true and an empty string for false.
This is not in line with the json specs (https://json-schema.org/understanding-json-schema/reference/boolean.html).

The proposed fix check if a field is an acceptance field. If so it will map value to be a string representation of boolean value.