### PR TITLE
Fix override message checkbox state

### DIFF
--- a/includes/class-cf7-api-admin.php
+++ b/includes/class-cf7-api-admin.php
@@ -201,7 +201,7 @@ class QS_CF7_api_admin{
           <div class="cf7_row">
 
               <label for="wpcf7-sf-override_message">
-                  <input type="checkbox" id="wpcf7-sf-override_message" name="wpcf7-sf[override_message]" <?php checked( $wpcf7_api_data["override_message"] , "off" );?>/>
+                  <input type="checkbox" id="wpcf7-sf-override_message" name="wpcf7-sf[override_message]" <?php checked( $wpcf7_api_data["override_message"] , "on" );?>/>
                   <?php _e( 'Override message with api response body?' , $this->textdomain );?>
               </label>
 


### PR DESCRIPTION
Minor fix so that the override message checkbox state actually works. Currently it will always show as unchecked even if it was checked and saved. I introduced this bug in pull request #43