### PR TITLE
make sure all fields are correctly JSON encoded

### DIFF
--- a/includes/class-cf7-api-admin.php
+++ b/includes/class-cf7-api-admin.php
@@ -558,12 +558,9 @@ endif;
               $image_content = file_get_contents($path);
               $value[] = base64_encode($image_content);
             }
-            
-            // replace "[$form_key]" with json array of base64 strings
-            $template = preg_replace( "/(\")?\[{$form_key}\](\")?/", json_encode($value), $template );
           }
-
-          $template = str_replace( "[{$form_key}]", $value, $template );
+          // replace "[$form_key]" with json-encoded value
+          $template = preg_replace( "/(\")?\[{$form_key}\](\")?/", json_encode($value), $template );
         }
       }
 


### PR DESCRIPTION
If the content of the form fields contain eg. double quotes or backslashes, they break the JSON encoding of the request.

This pull request fixes that by always using json_encode, not only for files but all values.

Example: 'Test"Ralf' --> "Test\"Ralf"
without: "Test"Ralf" which is obviously not ok.

Ralf 